### PR TITLE
Add option for multiple windows rather than one splitscreen window

### DIFF
--- a/Co-Op-On-Linux.sh
+++ b/Co-Op-On-Linux.sh
@@ -24,10 +24,21 @@ if [ "$1" = --help ]; then
     echo "
     Co-Op-On-Linux.sh
 
-    Enviroment variables:
+    Enviroment variables for splitscreen window:
 
     WIDTH: width of total area in pixels
     HEIGHT: height of total area in pixels
+    GAMERUN: command to run to start the game
+
+    Environmental variables for separate windows:
+    WIDTH1: width of first window
+    HEIGHT1: height of first window
+    WIDTH2: width of second window
+    HEIGHT2: height of second window
+    WIDTH3: (if applicable) width of third window
+    HEIGHT3: (if applicable) height of third window
+    WIDTH4: (if applicable) width of fourth window
+    HEIGHT4: (if applicable) height of fourth window
     GAMERUN: command to run to start the game
     "
 fi
@@ -92,9 +103,17 @@ function legacy_select_controllers() {
 };
 
 function select_controllers() {
+    if [ -z "$WIDTH" ] || [ -z "$HEIGHT" ]; then
+        width=$WIDTH1
+        height=$HEIGHT1
+    else
+        width=$WIDTH
+        height=$HEIGHT
+    fi
+
     rm $DIR_CO_OP/controllers.rc
     pushd $DIR_CO_OP/controller-selector
-      ./controller-selector -w $WIDTH -h $HEIGHT
+      ./controller-selector -w $width -h $height
     popd
     if ! [ -f $DIR_CO_OP/controllers.rc ]; then
       zenity --error --text "Controller selector failed to open or failed to generate controllers file"
@@ -104,8 +123,9 @@ function select_controllers() {
     load_controller_firejail_args_array
 }
 
-if [ -z $WIDTH ] || [ -z $HEIGHT ] || [ -z $GAMERUN ]; then
-    zenity --error --text "Enviroment variables not set (Did you run this without a preset?)"
+if ([ -z $WIDTH ] || [ -z $HEIGHT ] || [ -z $GAMERUN ]) &&
+   ([ -z $WIDTH1 ] || [ -z $HEIGHT1 ] || [ -z $WIDTH2 ] || [ -z $HEIGHT2 ] || [ -z $WIDTH3 ] || [ -z $HEIGHT3 ] || [ -z $WIDTH4 ] || [ -z $HEIGHT4 ] || [ -z $GAMERUN ]); then
+    zenity --error --text "Environment variables not set (Did you run this without a preset?)"
     exit
 fi
 
@@ -117,70 +137,90 @@ echo ${controller_firejail_args[*]}
 mkdir $DIR_CO_OP_SWAY
 rm "$DIR_CO_OP_SWAY"/*.conf
 
-# Set width and height for game instances
-child_width=0
-child_height=0
-if [ $CONTROLLERS_NUM -lt 3 ]; then
-    child_width=$(($WIDTH/2))
-    child_height=$HEIGHT
-else
-    child_width=$(($WIDTH/2))
-    child_height=$(($HEIGHT/2))
-fi
-
-# Initialize script that spawns the game instances
-mkdir -p /tmp/coop-linux
-SPAWN_SCRIPT=/tmp/coop-linux/spawn_instances.sh
-rm $SPAWN_SCRIPT; touch $SPAWN_SCRIPT
-echo "#!/usr/bin/env bash" >> $SPAWN_SCRIPT
-chmod u+x $SPAWN_SCRIPT
-
-# Create root sway config
-echo "default_border none 0" > $DIR_CO_OP_SWAY/sway_root.conf
-echo "output WL-1 resolution $(($WIDTH))x$HEIGHT" >> $DIR_CO_OP_SWAY/sway_root.conf
-# Set resolution for X11 and Xwayland compositors (eg. gamescope)
-echo "output X11-1 resolution $(($WIDTH))x$HEIGHT" >> $DIR_CO_OP_SWAY/sway_root.conf
-echo "exec $SPAWN_SCRIPT" >> $DIR_CO_OP_SWAY/sway_root.conf
-
-# Create sway config for instance containers
-for i in $(seq 0 $CONTROLLERS_NUM); do
-    echo "default_border none 0" > $DIR_CO_OP_SWAY/sway$i.conf
-    echo "output WL-1 resolution ${child_width}x${child_height}" >> $DIR_CO_OP_SWAY/sway$i.conf
-    exec_command="WAYLAND_DISPLAY=wayland-$i firejail --noprofile ${controller_firejail_args[$i]} $GAMERUN"
-    echo "exec $exec_command" >> $DIR_CO_OP_SWAY/sway$i.conf
-done
-
-if [ $CONTROLLERS_NUM -gt 2 ]; then
-    echo "swaymsg splith" >> $SPAWN_SCRIPT
-    echo "sleep 1" >> $SPAWN_SCRIPT
-    echo "swaymsg exec \"sway -c $DIR_CO_OP_SWAY/sway0.conf\"" >> $SPAWN_SCRIPT
-    echo "sleep 1" >> $SPAWN_SCRIPT
-    echo "swaymsg exec \"sway -c $DIR_CO_OP_SWAY/sway1.conf\"" >> $SPAWN_SCRIPT
-    echo "sleep 1" >> $SPAWN_SCRIPT
-    echo "swaymsg focus left" >> $SPAWN_SCRIPT
-    echo "sleep 1" >> $SPAWN_SCRIPT
-    echo "swaymsg splitv" >> $SPAWN_SCRIPT
-    echo "sleep 1" >> $SPAWN_SCRIPT
-    echo "swaymsg exec \"sway -c $DIR_CO_OP_SWAY/sway2.conf\"" >> $SPAWN_SCRIPT
-    echo "sleep 1" >> $SPAWN_SCRIPT
-    echo "swaymsg focus left" >> $SPAWN_SCRIPT
-    echo "sleep 1" >> $SPAWN_SCRIPT
-    echo "swaymsg splitv" >> $SPAWN_SCRIPT
-    echo "sleep 1" >> $SPAWN_SCRIPT
-    if [ $CONTROLLERS_NUM -eq 3 ]; then
-        echo "swaymsg exec glxgears" >> $SPAWN_SCRIPT
-    else
-        echo "swaymsg exec \"sway -c $DIR_CO_OP_SWAY/sway3.conf\"" >> $SPAWN_SCRIPT
-    fi
-else
-    for i in $(seq 0 $(($CONTROLLERS_NUM - 1))); do
-        echo "swaymsg exec \"sway -c $DIR_CO_OP_SWAY/sway$i.conf\"" >> $SPAWN_SCRIPT
+# Separate windows
+if [ -n "$WIDTH1" ] || [ -n "$HEIGHT1" ] || [ -n "$WIDTH2" ] || [ -n "$HEIGHT2" ] || [ -n "$WIDTH3" ] || [ -n "$HEIGHT3" ] || [ -n "$WIDTH4" ] || [ -n "$HEIGHT4" ]; then
+    # Create sway config for each instance
+    for i in $(seq 0 $((CONTROLLERS_NUM - 1))); do
+        echo "default_border none 0" > "$DIR_CO_OP_SWAY/sway$i.conf"
+        echo "output WL-1 resolution $(($(eval echo \$WIDTH$((i+1)))))x$(eval echo \$HEIGHT$((i+1)))" >> "$DIR_CO_OP_SWAY/sway$i.conf"
+        echo "output X11-1 resolution $(($(eval echo \$WIDTH$((i+1)))))x$(eval echo \$HEIGHT$((i+1)))" >> "$DIR_CO_OP_SWAY/sway$i.conf"
+        exec_command="WAYLAND_DISPLAY=wayland-$i firejail --noprofile ${controller_firejail_args[$i]} $GAMERUN"
+        echo "exec $exec_command" >> "$DIR_CO_OP_SWAY/sway$i.conf"
     done
-fi
 
-### Launching sway sessions
-cd $(dirname $GAMERUN)
-echo $PWD
-sway -c $DIR_CO_OP_SWAY/sway_root.conf &
+    ### Launching sway sessions
+    cd $(dirname $GAMERUN)
+    echo $PWD
+    for i in $(seq 0 $(($CONTROLLERS_NUM - 1))); do
+        sway -c $DIR_CO_OP_SWAY/sway$i.conf &
+    done
+# Splitscreen window
+elif [ -n "$WIDTH" ] && [ -n "$HEIGHT" ]; then
+    # Set width and height for game instances
+    child_width=0
+    child_height=0
+    if [ $CONTROLLERS_NUM -lt 3 ]; then
+        child_width=$(($WIDTH/2))
+        child_height=$HEIGHT
+    else
+        child_width=$(($WIDTH/2))
+        child_height=$(($HEIGHT/2))
+    fi
+
+    # Initialize script that spawns the game instances
+    mkdir -p /tmp/coop-linux
+    SPAWN_SCRIPT=/tmp/coop-linux/spawn_instances.sh
+    rm $SPAWN_SCRIPT; touch $SPAWN_SCRIPT
+    echo "#!/usr/bin/env bash" >> $SPAWN_SCRIPT
+    chmod u+x $SPAWN_SCRIPT
+
+    # Create root sway config
+    echo "default_border none 0" > $DIR_CO_OP_SWAY/sway_root.conf
+    echo "output WL-1 resolution $(($WIDTH))x$HEIGHT" >> $DIR_CO_OP_SWAY/sway_root.conf
+    # Set resolution for X11 and Xwayland compositors (eg. gamescope)
+    echo "output X11-1 resolution $(($WIDTH))x$HEIGHT" >> $DIR_CO_OP_SWAY/sway_root.conf
+    echo "exec $SPAWN_SCRIPT" >> $DIR_CO_OP_SWAY/sway_root.conf
+
+    # Create sway config for instance containers
+    for i in $(seq 0 $CONTROLLERS_NUM); do
+        echo "default_border none 0" > $DIR_CO_OP_SWAY/sway$i.conf
+        echo "output WL-1 resolution ${child_width}x${child_height}" >> $DIR_CO_OP_SWAY/sway$i.conf
+        exec_command="WAYLAND_DISPLAY=wayland-$i firejail --noprofile ${controller_firejail_args[$i]} $GAMERUN"
+        echo "exec $exec_command" >> $DIR_CO_OP_SWAY/sway$i.conf
+    done
+
+    if [ $CONTROLLERS_NUM -gt 2 ]; then
+        echo "swaymsg splith" >> $SPAWN_SCRIPT
+        echo "sleep 1" >> $SPAWN_SCRIPT
+        echo "swaymsg exec \"sway -c $DIR_CO_OP_SWAY/sway0.conf\"" >> $SPAWN_SCRIPT
+        echo "sleep 1" >> $SPAWN_SCRIPT
+        echo "swaymsg exec \"sway -c $DIR_CO_OP_SWAY/sway1.conf\"" >> $SPAWN_SCRIPT
+        echo "sleep 1" >> $SPAWN_SCRIPT
+        echo "swaymsg focus left" >> $SPAWN_SCRIPT
+        echo "sleep 1" >> $SPAWN_SCRIPT
+        echo "swaymsg splitv" >> $SPAWN_SCRIPT
+        echo "sleep 1" >> $SPAWN_SCRIPT
+        echo "swaymsg exec \"sway -c $DIR_CO_OP_SWAY/sway2.conf\"" >> $SPAWN_SCRIPT
+        echo "sleep 1" >> $SPAWN_SCRIPT
+        echo "swaymsg focus left" >> $SPAWN_SCRIPT
+        echo "sleep 1" >> $SPAWN_SCRIPT
+        echo "swaymsg splitv" >> $SPAWN_SCRIPT
+        echo "sleep 1" >> $SPAWN_SCRIPT
+        if [ $CONTROLLERS_NUM -eq 3 ]; then
+            echo "swaymsg exec glxgears" >> $SPAWN_SCRIPT
+        else
+            echo "swaymsg exec \"sway -c $DIR_CO_OP_SWAY/sway3.conf\"" >> $SPAWN_SCRIPT
+        fi
+    else
+        for i in $(seq 0 $(($CONTROLLERS_NUM - 1))); do
+            echo "swaymsg exec \"sway -c $DIR_CO_OP_SWAY/sway$i.conf\"" >> $SPAWN_SCRIPT
+        done
+    fi
+
+    ### Launching sway sessions
+    cd $(dirname $GAMERUN)
+    echo $PWD
+    sway -c $DIR_CO_OP_SWAY/sway_root.conf &
+fi
 
 echo "Done~!"

--- a/README.md
+++ b/README.md
@@ -33,9 +33,12 @@ To create a profile execute the `create-new-profile.sh` script and follow the in
 - Game executable
 :   Select the executable for the game, you can also just write a command to execute 
    (This is useful for wine games)
+
+- Splitscreen or Separate Windows
+: Choose whether you want 2-4 smaller screens inside one window, or each player to have their own window
  
 - Resolution
-:   Specify the total resolution of the screen, this will be then divided for the game instances
+: If you chose splitscreen window, specify the total resolution of the screen, this will be then divided for the game instances -- if you chose separate windows, specify the resolution for each separate window (number of windows used will be based on number of controllers)
 
 - Name
 :   The name of the profile

--- a/create-new-profile.sh
+++ b/create-new-profile.sh
@@ -10,18 +10,48 @@ else
 fi
 
 DEFAULT_RES=$(xdpyinfo | awk '/dimensions/{print $2}')
-RESOLUTION=$($DIALOG --title="Resolution" --entry --text="Enter screen resolution ( for example: 1280x720 ) " --entry-text=$DEFAULT_RES)
 
-WIDTH=$(printf $RESOLUTION | awk -F "x" '{print $1}')
-HEIGHT=$(printf $RESOLUTION | awk -F "x" '{print $2}')
+MULTIWINDOW=$($DIALOG --title="Separate Windows Per Player?" --list --radiolist --column "Pick" --column "Option" TRUE "Splitscreen Window" FALSE "Separate Windows")
+
+if [ "$MULTIWINDOW" = "Separate Windows" ]; then
+    RESOLUTION1=$($DIALOG --title="Resolution" --entry --text="Enter screen resolution for player 1 ( for example: 1280x720 ) " --entry-text=$DEFAULT_RES)
+    WIDTH1=$(printf $RESOLUTION1 | awk -F "x" '{print $1}')
+    HEIGHT1=$(printf $RESOLUTION1 | awk -F "x" '{print $2}')
+    RESOLUTION2=$($DIALOG --title="Resolution" --entry --text="Enter screen resolution for player 2 ( for example: 1280x720 ) " --entry-text=$DEFAULT_RES)
+    WIDTH2=$(printf $RESOLUTION2 | awk -F "x" '{print $1}')
+    HEIGHT2=$(printf $RESOLUTION2 | awk -F "x" '{print $2}')
+    RESOLUTION3=$($DIALOG --title="Resolution" --entry --text="(If Applicable) Enter screen resolution for player 3 ( for example: 1280x720 ) " --entry-text=$DEFAULT_RES)
+    WIDTH3=$(printf $RESOLUTION3 | awk -F "x" '{print $1}')
+    HEIGHT3=$(printf $RESOLUTION3 | awk -F "x" '{print $2}')
+    RESOLUTION4=$($DIALOG --title="Resolution" --entry --text="(If Applicable) Enter screen resolution for player 4 ( for example: 1280x720 ) " --entry-text=$DEFAULT_RES)
+    WIDTH4=$(printf $RESOLUTION4 | awk -F "x" '{print $1}')
+    HEIGHT4=$(printf $RESOLUTION4 | awk -F "x" '{print $2}')
+elif [ "$MULTIWINDOW" = "Splitscreen Window" ]; then
+    RESOLUTION=$($DIALOG --title="Resolution" --entry --text="Enter screen resolution ( for example: 1280x720 ) " --entry-text=$DEFAULT_RES)
+    WIDTH=$(printf $RESOLUTION | awk -F "x" '{print $1}')
+    HEIGHT=$(printf $RESOLUTION | awk -F "x" '{print $2}')
+fi
 
 name=$($DIALOG --title="Profile name" --entry --text="Enter a name for the profile" --entry-text="name")
 mkdir -p "$DIR_CO_OP"/profiles
 echo "#!/bin/bash" > "$DIR_CO_OP/profiles/$name.sh"
-echo "export WIDTH=$WIDTH" >> "$DIR_CO_OP/profiles/$name.sh"
-echo "export HEIGHT=$HEIGHT" >> "$DIR_CO_OP/profiles/$name.sh"
+
+if [ "$MULTIWINDOW" = "Separate Windows" ]; then
+    echo "export WIDTH1=$WIDTH1" >> "$DIR_CO_OP/profiles/$name.sh"
+    echo "export HEIGHT1=$HEIGHT1" >> "$DIR_CO_OP/profiles/$name.sh"
+    echo "export WIDTH2=$WIDTH2" >> "$DIR_CO_OP/profiles/$name.sh"
+    echo "export HEIGHT2=$HEIGHT2" >> "$DIR_CO_OP/profiles/$name.sh"
+    echo "export WIDTH3=$WIDTH3" >> "$DIR_CO_OP/profiles/$name.sh"
+    echo "export HEIGHT3=$HEIGHT3" >> "$DIR_CO_OP/profiles/$name.sh"
+    echo "export WIDTH4=$WIDTH4" >> "$DIR_CO_OP/profiles/$name.sh"
+    echo "export HEIGHT4=$HEIGHT4" >> "$DIR_CO_OP/profiles/$name.sh"
+elif [ "$MULTIWINDOW" = "Splitscreen Window" ]; then
+    echo "export WIDTH=$WIDTH" >> "$DIR_CO_OP/profiles/$name.sh"
+    echo "export HEIGHT=$HEIGHT" >> "$DIR_CO_OP/profiles/$name.sh"
+fi
+
 echo "export GAMERUN='$GAMERUN'" >> "$DIR_CO_OP/profiles/$name.sh"
 echo "../Co-Op-On-Linux.sh" >> "$DIR_CO_OP/profiles/$name.sh"
 chmod +x "$DIR_CO_OP/profiles/$name.sh"
 
-zenity --info --text "Preset created! To load it go to the preset folder and execute it's script"
+zenity --info --text "Preset created! To load it go to the preset folder and execute its script"


### PR DESCRIPTION
The create new preset script now gives the option for splitscreen or separate windows, and then adds WIDTH HEIGHT or  WIDTH1 HEIGHT1 WIDTH2 HEIGHT2 etc to the preset. The Co-Op-On-Linux script then acts accordingly based on which set of variables is present. For the separate windows, it doesn't create sway_root.conf or spawn_instances.sh, it just launches the sway instances directly. The controller selector wasn't working for me so I'll open an issue for that, but the new code should work fine with it.