### PR TITLE
Fixed duplication of first resolution entered when using multiwndow

### DIFF
--- a/create-new-profile.sh
+++ b/create-new-profile.sh
@@ -18,7 +18,7 @@ if [ "$MULTIWINDOW" = "Separate Windows" ]; then
     declare -a MW_WIDTHS
     declare -a MW_HEIGHTS
     for i in $(seq 0 $((NUM_WINDOWS - 1))); do
-      RESOLUTION+=($($DIALOG --title="Resolution" --entry --text="Enter screen resolution for player 1 ( for example: 1280x720 ) " --entry-text=$DEFAULT_RES))
+      RESOLUTION=($($DIALOG --title="Resolution" --entry --text="Enter screen resolution for player 1 ( for example: 1280x720 ) " --entry-text=$DEFAULT_RES))
       MW_WIDTHS+=($(printf $RESOLUTION | awk -F "x" '{print $1}'))
       MW_HEIGHTS+=($(printf $RESOLUTION | awk -F "x" '{print $2}'))
     done


### PR DESCRIPTION
RESOLUTION was being treated as an array because of the + sign, causing WIDTH2/HEIGHT2 etc to all be the same as WIDTH1/HEIGHT1.